### PR TITLE
Do not allow launched sites to be deleted. Resolves #473.

### DIFF
--- a/atlas/callbacks.py
+++ b/atlas/callbacks.py
@@ -209,9 +209,18 @@ def pre_delete_sites(request, lookup):
     :param request: flask.request object
     :param lookup:
     """
-    log.debug('sites | Pre Delete | lookup - %s', lookup)
-    site = utilities.get_single_eve('sites', lookup['_id'])
-    tasks.site_remove.delay(site)
+    log.debug('Instances | Pre Delete | lookup - %s', lookup)
+    instance = utilities.get_single_eve('sites', lookup['_id'])
+    log.debug('Instances | Pre Delete | instance - %s', instance)
+
+    # Check if instance is launched.
+    if not instance['status'] in ['launched', 'launching']:
+        log.debug('Instances | Pre Delete | instance - %s | Instance state - %s | Okay to delete', instance, instance['status'])
+        tasks.site_remove.delay(instance)
+    else:
+        log.error('Instances | Delete | instance - %s | Instance is launched or launching',
+                  instance['_id'])
+        abort(409, 'Instance is launched or launching. To delete, take instance down first.')
 
 
 def on_delete_item_code(item):


### PR DESCRIPTION
Logging output from local test

```
==> /var/log/httpd/error_log <==
[Fri Jun 15 15:35:18.122230 2018] [:error] [pid 4491] --------------------------------------------------------------------------------
[Fri Jun 15 15:35:18.122254 2018] [:error] [pid 4491] DEBUG in callbacks [/data/code/atlas/atlas/callbacks.py:212]:
[Fri Jun 15 15:35:18.122260 2018] [:error] [pid 4491] Instances | Pre Delete | lookup - {'_id': u'5b2148ae3d187212e614f0f0'}
[Fri Jun 15 15:35:18.122264 2018] [:error] [pid 4491] --------------------------------------------------------------------------------

==> /var/log/httpd/error_log <==
[Fri Jun 15 15:35:18.122705 2018] [:error] [pid 4491] --------------------------------------------------------------------------------
[Fri Jun 15 15:35:18.122724 2018] [:error] [pid 4491] DEBUG in utilities [/data/code/atlas/atlas/utilities.py:255]:
[Fri Jun 15 15:35:18.122730 2018] [:error] [pid 4491] utilities | Get Eve Single | url - https://python.local/atlas/sites/5b2148ae3d187212e614f0f0
[Fri Jun 15 15:35:18.122735 2018] [:error] [pid 4491] --------------------------------------------------------------------------------

==> /var/log/httpd/access_log <==
192.168.33.21 - - [15/Jun/2018:15:35:18 +0000] "GET /atlas/sites/5b2148ae3d187212e614f0f0 HTTP/1.1" 200 1162 "-" "python-requests/2.18.3"

==> /var/log/httpd/error_log <==
[Fri Jun 15 15:35:18.135462 2018] [:error] [pid 4491] --------------------------------------------------------------------------------
[Fri Jun 15 15:35:18.135489 2018] [:error] [pid 4491] DEBUG in callbacks [/data/code/atlas/atlas/callbacks.py:214]:
[Fri Jun 15 15:35:18.135496 2018] [:error] [pid 4491] Instances | Pre Delete | instance - {u'status': u'launched', u'_latest_version': 6, u'dates': {u'assigned': u'2018-06-13 19:00:09 GMT', u'launched': u'2018-06-15 15:34:34 GMT', u'created': u'2018-06-13 16:39:10 GMT'}, u'code': {u'profile': u'5b2141e13d187208e00c91f4', u'core': u'5b2141e03d187208e00c91f2'}, u'modified_by': u'osr_atlas_client', u'_updated': u'2018-06-15 15:34:37 GMT', u'settings': {u'page_cache_maximum_age': 10800}, u'sid': u'p1d1374964a2', u'_version': 6, u'created_by': u'osr_atlas_client', u'update_group': 2, u'statistics': u'5b2148ae3d187212e2447ef7', u'_deleted': False, u'_links': {u'self': {u'href': u'sites/5b2148ae3d187212e614f0f0', u'title': u'site'}, u'parent': {u'href': u'/', u'title': u'home'}, u'collection': {u'href': u'sites', u'title': u'sites'}}, u'path': u'launch1', u'_id': u'5b2148ae3d187212e614f0f0', u'type': u'express', u'_etag': u'71b6363b2d895bd1f5234f08b055d07673958b53', u'_created': u'2018-06-13 16:39:10 GMT'}
[Fri Jun 15 15:35:18.135503 2018] [:error] [pid 4491] --------------------------------------------------------------------------------

==> /var/log/httpd/error_log <==
[Fri Jun 15 15:35:18.136068 2018] [:error] [pid 4491] --------------------------------------------------------------------------------
[Fri Jun 15 15:35:18.136094 2018] [:error] [pid 4491] ERROR in callbacks [/data/code/atlas/atlas/callbacks.py:222]:
[Fri Jun 15 15:35:18.136103 2018] [:error] [pid 4491] Instances | Delete | instance - 5b2148ae3d187212e614f0f0 | Instance is launched or launching
[Fri Jun 15 15:35:18.136108 2018] [:error] [pid 4491] --------------------------------------------------------------------------------

==> /var/log/httpd/access_log <==
192.168.33.1 - - [15/Jun/2018:15:35:17 +0000] "DELETE /atlas/sites/5b2148ae3d187212e614f0f0 HTTP/1.1" 409 91 "-" "PostmanRuntime/7.1.5"
```