### PR TITLE
Run drush site-install with alternate primary group.

### DIFF
--- a/atlas/fabric_tasks.py
+++ b/atlas/fabric_tasks.py
@@ -137,7 +137,12 @@ def site_install(site):
 
     try:
         with cd(code_directory_current):
-            run('drush site-install -y {0}'.format(profile_name))
+            """
+            Run drush site-install with alternate primary group to avoid
+            NFS file permission issues on file creation after drush drops
+            the setgid group on the files directory
+            """
+            run('sg {1} -c "drush site-install -y {0}"'.format(profile_name, WEBSERVER_USER_GROUP),)
     except FabricException as error:
         log.error('Site | Install | Instance install failed | Error - %s', error)
         return error
@@ -318,7 +323,7 @@ def import_backup(backup, target_instance, source_env=ENVIRONMENT):
 
     with cd(nfs_files_dir):
         run('tar -xzf {0}'.format(files_path))
-        run('find {0} -type f -or -type d -exec chgrp apache {{}} \\;'.format(nfs_files_dir), warn_only=True)
+        run('find {0} -type f -or -type d -exec chgrp {1} {{}} \\;'.format(nfs_files_dir, WEBSERVER_USER_GROUP), warn_only=True)
         run('find {0} -type f -exec chmod g+rw {{}} \\;'.format(nfs_files_dir), warn_only=True)
         run('find {0} -type d -exec chmod g+rws {{}} \\;'.format(nfs_files_dir), warn_only=True)
         log.debug('Instance | Restore Backup | Files replaced')

--- a/atlas/fabric_tasks.py
+++ b/atlas/fabric_tasks.py
@@ -323,7 +323,8 @@ def import_backup(backup, target_instance, source_env=ENVIRONMENT):
 
     with cd(nfs_files_dir):
         run('tar -xzf {0}'.format(files_path))
-        run('find {0} -type f -or -type d -exec chgrp {1} {{}} \\;'.format(nfs_files_dir, WEBSERVER_USER_GROUP), warn_only=True)
+        run('find {0} -type f -or -type d -exec chgrp {1} {{}} \\;'
+            .format(nfs_files_dir, WEBSERVER_USER_GROUP), warn_only=True)
         run('find {0} -type f -exec chmod g+rw {{}} \\;'.format(nfs_files_dir), warn_only=True)
         run('find {0} -type d -exec chmod g+rws {{}} \\;'.format(nfs_files_dir), warn_only=True)
         log.debug('Instance | Restore Backup | Files replaced')


### PR DESCRIPTION
By running the site-install operation under the WEBSERVER_USER_GROUP group, the util server can later fix up the files directory permissions that drush sets to 777. 

Fixed another instance where the group was being called directly, rather than with the config variable, WEBSERVER_USER_GROUP.