### PR TITLE
Add a check to prevent code assets where `is_current` is `true` begin deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Resolves:
 
 - &#35;507 - Deploy bundles into Express profile
 - &#35;579 - Current symlinks are not being removed when code item is patched
+- &#35;584 - Use the 'is_current' field as a lock to prevent deleting code assets
 
 ## v2.3.0-alpha9
 

--- a/atlas/callbacks.py
+++ b/atlas/callbacks.py
@@ -96,8 +96,8 @@ def pre_delete_code(request, lookup):
     log.debug('code | Delete | code - %s', code)
     
     if code['meta']['is_current']:
-        abort(409, 'A conflict happened while processing the request. `meta.is_current` must be false in order to delete the code item.')
         log.error('code | Delete | code - %s | Code item is current', code['_id'])
+        abort(409, 'A conflict happened while processing the request. `meta.is_current` must be false in order to delete the code item.')
 
     # Check for sites using this piece of code.
     if code['meta']['code_type'] in ['module', 'theme', 'library']:

--- a/atlas/callbacks.py
+++ b/atlas/callbacks.py
@@ -94,7 +94,7 @@ def pre_delete_code(request, lookup):
     """
     code = utilities.get_single_eve('code', lookup['_id'])
     log.debug('code | Delete | code - %s', code)
-    
+
     if code['meta']['is_current']:
         log.error('code | Delete | code - %s | Code item is current', code['_id'])
         abort(409, 'A conflict happened while processing the request. `meta.is_current` must be false in order to delete the code item.')

--- a/atlas/callbacks.py
+++ b/atlas/callbacks.py
@@ -94,6 +94,8 @@ def pre_delete_code(request, lookup):
     """
     code = utilities.get_single_eve('code', lookup['_id'])
     log.debug('code | Delete | code - %s', code)
+    if code['meta']['is_current']:
+        abort(409, 'A conflict happened while processing the request. `meta.is_current` must be false in order to delete the code item.')
 
     # Check for sites using this piece of code.
     if code['meta']['code_type'] in ['module', 'theme', 'library']:

--- a/atlas/callbacks.py
+++ b/atlas/callbacks.py
@@ -94,8 +94,10 @@ def pre_delete_code(request, lookup):
     """
     code = utilities.get_single_eve('code', lookup['_id'])
     log.debug('code | Delete | code - %s', code)
+    
     if code['meta']['is_current']:
         abort(409, 'A conflict happened while processing the request. `meta.is_current` must be false in order to delete the code item.')
+        log.error('code | Delete | code - %s | Code item is current', code['_id'])
 
     # Check for sites using this piece of code.
     if code['meta']['code_type'] in ['module', 'theme', 'library']:


### PR DESCRIPTION
Test conditions:

1. Create code item that is current
   * Cannot delete item
1. Create code item that is not current
   * Can delete item
1. Create a code item that is not current and add it to an instance
   * Cannot delete item