### PR TITLE
new: Added support for express_site_metrics endpoint in the express_mono repo

### DIFF
--- a/atlas/config_local.py.example
+++ b/atlas/config_local.py.example
@@ -74,3 +74,6 @@ EMAIL_USERNAME = ''
 EMAIL_PASSWORD = ''
 # List of users to exlude from any notification emails
 EMAIL_USERS_EXCLUDE = ['test@example.com','osr-test-owner@example.com','osr-test-edit-own@example.com','osr-test-content@example.com']
+
+# Express Site Metrics Settings
+EXPRESS_SITE_METRICS_SECRET = ''

--- a/atlas/instance_operations.py
+++ b/atlas/instance_operations.py
@@ -342,7 +342,8 @@ def switch_settings_files(instance):
         'smtp_password': SMTP_PASSWORD,
         'base_url': BASE_URLS[ENVIRONMENT],
         'domain': domain,
-        'servicenow_key': SERVICENOW_KEY
+        'servicenow_key': SERVICENOW_KEY,
+        'express_site_metrics_secret': EXPRESS_SITE_METRICS_SECRET
     }
 
     log.info('Instance | Settings file | Render settings file | Instance ID - %s', instance['_id'])

--- a/atlas/templates/settings.php
+++ b/atlas/templates/settings.php
@@ -25,6 +25,8 @@ $conf["atlas_status"] = "{{status}}";
 $conf["atlas_statistics_id"] = "{{atlas_statistics_id}}";
 $conf["atlas_logging_url"] = "{{atlas_logging_url|join(sid)}}";
 
+// Express Site Metrics
+$conf['express_site_metrics_secret'] = "{{express_site_metrics_secret}}";
 $path = "{{path}}";
 {% if status in ['launched', 'launching'] -%}
 $launched = TRUE;


### PR DESCRIPTION
Updated a few files to support add `$conf['express_site_metrics_secret']` to the settings.php file while keeping it secret.

The actual atlas config file will need to be updated as well so that `EXPRESS_SITE_METRICS = '<AnActualSecret>'`.